### PR TITLE
[feat] 챌린지 미션 제출자수 기준 변경

### DIFF
--- a/src/main/java/org/letscareer/letscareer/domain/mission/dto/response/MissionAdminResponseDto.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/dto/response/MissionAdminResponseDto.java
@@ -18,6 +18,7 @@ public record MissionAdminResponseDto(
         MissionStatusType missionStatusType,
         Long attendanceCount,
         Long lateAttendanceCount,
+        Long wrongAttendanceCount,
         Long applicationCount,
         Integer score,
         Integer lateScore,
@@ -39,6 +40,7 @@ public record MissionAdminResponseDto(
                 .missionStatusType(vo.missionStatusType())
                 .attendanceCount(vo.attendanceCount())
                 .lateAttendanceCount(vo.lateAttendanceCount())
+                .wrongAttendanceCount(vo.wrongAttendanceCount())
                 .applicationCount(applicationCount)
                 .score(vo.score())
                 .lateScore(vo.lateScore())

--- a/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
@@ -47,6 +47,7 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                         mission.missionStatusType,
                         getAttendanceCount(),
                         getLateAttendanceCount(),
+                        getWrongAttendanceCount(),
                         missionScore.successScore,
                         missionScore.lateScore,
                         missionTemplate.id,
@@ -300,7 +301,6 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                 .where(
                         attendance.mission.eq(mission)
                                 .and(attendance.status.notIn(AttendanceStatus.ABSENT))
-                                .and(attendance.result.notIn(AttendanceResult.WRONG))
                 );
     }
 
@@ -310,7 +310,15 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                 .where(
                         attendance.mission.eq(mission)
                                 .and(attendance.status.in(AttendanceStatus.LATE))
-                                .and(attendance.result.notIn(AttendanceResult.WRONG))
+                );
+    }
+
+    private Expression<Long> getWrongAttendanceCount() {
+        return JPAExpressions.select(attendance.result.count())
+                .from(attendance)
+                .where(
+                        attendance.mission.eq(mission)
+                                .and(attendance.result.in(AttendanceResult.WRONG))
                 );
     }
 

--- a/src/main/java/org/letscareer/letscareer/domain/mission/vo/MissionForChallengeVo.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/vo/MissionForChallengeVo.java
@@ -14,6 +14,7 @@ public record MissionForChallengeVo(
         MissionStatusType missionStatusType,
         Long attendanceCount,
         Long lateAttendanceCount,
+        Long wrongAttendanceCount,
         Integer score,
         Integer lateScore,
         Long missionTemplateId,


### PR DESCRIPTION
API: [어드민] 챌린지 1개의 미션 전체 목록

[수정] attendanceCount: ‘미제출’ 제외한 참여자 수 (확인 여부 상관없이)

[수정] lateAttendanceCount: ‘지각제출’한 참여자 수 (확인 여부 상관없이)

[추가] rejectedAttendanceCount: ‘반려’된 참여자 수 (제출 여부 상관없이)