### PR TITLE
LC-2168-feat 0회차 OT 미션 구현

### DIFF
--- a/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
@@ -61,13 +61,14 @@ public class Attendance extends BaseTimeEntity {
     private User mentor;
 
     public static Attendance createAttendance(Mission mission,
-                                              CreateAttendanceRequestDto createRequestDto,
-                                              AttendanceStatus status,
-                                              User user) {
+            CreateAttendanceRequestDto createRequestDto,
+            AttendanceStatus status,
+            User user, AttendanceResult result) {
         return Attendance.builder()
                 .link(createRequestDto.link())
                 .review(createRequestDto.review())
                 .status(status)
+                .result(result)
                 .mission(mission)
                 .user(user)
                 .build();

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/error/AttendanceErrorCode.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/error/AttendanceErrorCode.java
@@ -12,7 +12,8 @@ public enum AttendanceErrorCode implements ErrorCode {
     ATTENDANCE_NOT_AVAILABLE_DATE(HttpStatus.BAD_REQUEST, "출석 제출이 불가능한 기간입니다"),
     ATTENDANCE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "출석 수정 권한이 없습니다"),
     CONFLICT_ATTENDANCE(HttpStatus.CONFLICT, "이미 제출한 출석 내역이 존재합니다"),
-    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출석 정보를 찾을 수 없습니다.");
+    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출석 정보를 찾을 수 없습니다"),
+    ATTENDANCE_OT_REQUIRED(HttpStatus.BAD_REQUEST, "OT를 먼저 완료해주세요");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
@@ -5,6 +5,7 @@ import org.letscareer.letscareer.domain.attendance.dto.request.CreateAttendanceR
 import org.letscareer.letscareer.domain.attendance.entity.Attendance;
 import org.letscareer.letscareer.domain.attendance.error.AttendanceErrorCode;
 import org.letscareer.letscareer.domain.attendance.repository.AttendanceRepository;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
 import org.letscareer.letscareer.domain.attendance.type.AttendanceStatus;
 import org.letscareer.letscareer.domain.attendance.vo.*;
 import org.letscareer.letscareer.domain.mission.entity.Mission;
@@ -65,8 +66,10 @@ public class AttendanceHelper {
         }
     }
 
-    public Attendance createAttendanceAndSave(Mission mission, CreateAttendanceRequestDto createRequestDto, AttendanceStatus status, User user) {
-        Attendance newAttendance = Attendance.createAttendance(mission, createRequestDto, status, user);
+    public Attendance createAttendanceAndSave(Mission mission, CreateAttendanceRequestDto createRequestDto,
+            AttendanceStatus status, User user) {
+        AttendanceResult result = (mission.getTh() == 0) ? AttendanceResult.PASS : AttendanceResult.WAITING;
+        Attendance newAttendance = Attendance.createAttendance(mission, createRequestDto, status, user, result);
         return attendanceRepository.save(newAttendance);
     }
 
@@ -76,5 +79,10 @@ public class AttendanceHelper {
 
     public List<MissionReviewAdminVo> findAllMissionReviewAdminVos() {
         return attendanceRepository.findAllMissionReviewAdminVos();
+    }
+
+    public boolean isOTCompleted(Long challengeId, Long userId) {
+        return attendanceRepository.existsByMissionChallengeIdAndMissionThAndUserIdAndResult(challengeId, 0, userId,
+                AttendanceResult.PASS);
     }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
@@ -1,10 +1,14 @@
 package org.letscareer.letscareer.domain.attendance.repository;
 
 import org.letscareer.letscareer.domain.attendance.entity.Attendance;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long>, AttendanceQueryRepository {
     Optional<Attendance> findAttendanceByMissionIdAndUserId(Long missionId, Long userId);
+
+    boolean existsByMissionChallengeIdAndMissionThAndUserIdAndResult(
+            Long challengeId, Integer th, Long userId, AttendanceResult result);
 }

--- a/src/main/java/org/letscareer/letscareer/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/challenge/service/ChallengeServiceImpl.java
@@ -88,6 +88,7 @@ import org.letscareer.letscareer.domain.user.type.UserRole;
 import org.letscareer.letscareer.global.common.entity.PageInfo;
 import org.letscareer.letscareer.global.common.utils.zoom.ZoomUtils;
 import org.letscareer.letscareer.global.error.exception.EntityNotFoundException;
+import org.letscareer.letscareer.global.error.exception.InvalidValueException;
 import org.letscareer.letscareer.global.error.exception.UnauthorizedException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -101,6 +102,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.letscareer.letscareer.domain.application.error.ApplicationErrorCode.APPLICATION_NOT_FOUND;
+import static org.letscareer.letscareer.domain.attendance.error.AttendanceErrorCode.ATTENDANCE_OT_REQUIRED;
 import static org.letscareer.letscareer.domain.user.error.UserErrorCode.IS_NOT_MENTOR;
 
 @RequiredArgsConstructor
@@ -329,6 +331,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     public GetChallengeMyMissionDetailResponseDto getMyMissionDetail(Long challengeId, Long missionId, User user) {
         challengeApplicationHelper.validateChallengeDashboardAccessibleUser(challengeId, user);
         MyDailyMissionVo missionInfo = missionHelper.findMyDailyMissionVoByMissionId(missionId);
+        
+        if (missionInfo != null && missionInfo.th() >= 1 && !attendanceHelper.isOTCompleted(challengeId, user.getId())) {
+            throw new InvalidValueException(ATTENDANCE_OT_REQUIRED);
+        }
+        
         AttendanceDashboardVo attendanceInfo = missionInfo != null ? attendanceHelper.findAttendanceDashboardVoOrNull(missionInfo.id(), user.getId()) : null;
         return missionMapper.toGetChallengeMyMissionDetailResponseDto(missionInfo, attendanceInfo);
     }

--- a/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
@@ -132,7 +132,8 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                                 missionTemplate.missionTag,
                                 missionTemplate.description,
                                 missionTemplate.guide,
-                                missionTemplate.templateLink))
+                                missionTemplate.templateLink,
+                                missionTemplate.vodLink))
                         .from(mission)
                         .leftJoin(mission.missionTemplate, missionTemplate)
                         .where(
@@ -292,7 +293,8 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                                 missionTemplate.missionTag,
                                 missionTemplate.description,
                                 missionTemplate.guide,
-                                missionTemplate.templateLink))
+                                missionTemplate.templateLink,
+                                missionTemplate.vodLink))
                         .from(mission)
                         .leftJoin(mission.missionTemplate, missionTemplate)
                         .where(

--- a/src/main/java/org/letscareer/letscareer/domain/mission/vo/MyDailyMissionVo.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/vo/MyDailyMissionVo.java
@@ -22,9 +22,9 @@ public record MyDailyMissionVo(
         String missionTag,
         String description,
         String guide,
-        String templateLink
-) {
-    public MyDailyMissionVo(Mission mission, String missionTag, String description, String guide, String templateLink) {
+        String templateLink,
+        String vodLink) {
+    public MyDailyMissionVo(Mission mission, String missionTag, String description, String guide, String templateLink, String vodLink) {
         this(
                 mission.getId(),
                 mission.getTh(),
@@ -41,8 +41,8 @@ public record MyDailyMissionVo(
                 missionTag,
                 description,
                 guide,
-                templateLink
-        );
+                templateLink,
+                vodLink);
 
     }
 }


### PR DESCRIPTION
## 요약
- 0회차 OT 미션 VOD 링크 조회 기능 구현
- 0회차 미션 제출 시 자동 승인 처리
- 1회차 이상 미션 접근 시 0회차 완료 여부 체크 및 접근 제어
                                                                                                                                                                                                                                                               
## 변경사항
### 0회차 미션 VOD 링크 조회
- `MyDailyMissionVo`에 `vodLink` 필드 추가
- `MissionQueryRepositoryImpl`에서 `MissionTemplate.vodLink` 포함하여 조회
- 0회차 미션 상세 조회 시 YouTube 링크 등 VOD 콘텐츠 제공

### 0회차 미션 자동 승인
- `Attendance.createAttendance()` 메서드에 `result` 파라미터 추가
- `AttendanceHelper.createAttendanceAndSave()`에서 0회차 미션 제출 시 자동으로 `AttendanceResult.PASS` 설정
- 일반 미션은 기존대로 `AttendanceResult.WAITING` 상태로 생성

### 1회차 이상 미션 접근 제어
- `AttendanceHelper.isOTCompleted()` 메서드 추가 - 0회차 완료 여부 체크
- `ChallengeServiceImpl.getMyMissionDetail()`에서 `th >= 1` 미션 접근 시 0회차 완료 검증
- 0회차 미완료 시 `ATTENDANCE_OT_REQUIRED` 에러 발생

### 에러 처리
- `AttendanceErrorCode`에 `ATTENDANCE_OT_REQUIRED` 추가
- "OT를 먼저 완료해주세요" 메시지로 사용자 안내

## API 변경사항

### 수정된 API
- `GET /api/v1/challenge/{challengeId}/missions/{missionId}` - 0회차 완료 체크 및 VOD 링크 포함
- `POST /api/v1/attendance/{missionId}` - 0회차 제출 시 자동 승인