### PR TITLE
LC-2170-fix 구매한 플랜 pricePlanType 조회 기능 추가

### DIFF
--- a/src/main/java/org/letscareer/letscareer/domain/application/repository/ApplicationQueryRepositoryImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/application/repository/ApplicationQueryRepositoryImpl.java
@@ -54,8 +54,10 @@ public class ApplicationQueryRepositoryImpl implements ApplicationQueryRepositor
                         vWApplication.programStartDate,
                         vWApplication.programEndDate,
                         vWApplication.reviewId,
-                        vWApplication.paymentId))
+                        vWApplication.paymentId,
+                        payment.challengePricePlanType))
                 .from(vWApplication)
+                .leftJoin(payment).on(payment.id.eq(vWApplication.paymentId))
                 .where(
                         eqUserId(userId),
                         eqIsCanceled(false),
@@ -81,8 +83,10 @@ public class ApplicationQueryRepositoryImpl implements ApplicationQueryRepositor
                         vWApplication.programStartDate,
                         vWApplication.programEndDate,
                         vWApplication.reviewId,
-                        vWApplication.paymentId))
+                        vWApplication.paymentId,
+                        payment.challengePricePlanType))
                 .from(vWApplication)
+                .leftJoin(payment).on(payment.id.eq(vWApplication.paymentId))
                 .where(
                         eqUserId(userId),
                         eqIsCanceled(false),

--- a/src/main/java/org/letscareer/letscareer/domain/application/vo/MyApplicationVo.java
+++ b/src/main/java/org/letscareer/letscareer/domain/application/vo/MyApplicationVo.java
@@ -2,6 +2,7 @@ package org.letscareer.letscareer.domain.application.vo;
 
 import lombok.Builder;
 import org.letscareer.letscareer.domain.application.type.ApplicationStatus;
+import org.letscareer.letscareer.domain.price.type.ChallengePricePlanType;
 import org.letscareer.letscareer.domain.program.type.ProgramStatusType;
 import org.letscareer.letscareer.domain.program.type.ProgramType;
 import org.letscareer.letscareer.domain.report.type.ReportType;
@@ -23,7 +24,8 @@ public record MyApplicationVo(
         LocalDateTime programStartDate,
         LocalDateTime programEndDate,
         Long reviewId,
-        Long paymentId
+        Long paymentId,
+        ChallengePricePlanType pricePlanType
 ) {
     public MyApplicationVo(Long id,
                            LocalDateTime createDate,
@@ -37,7 +39,8 @@ public record MyApplicationVo(
                            LocalDateTime programStartDate,
                            LocalDateTime programEndDate,
                            Long reviewId,
-                           Long paymentId) {
+                           Long paymentId,
+                           ChallengePricePlanType pricePlanType) {
         this(
                 id,
                 createDate,
@@ -52,7 +55,8 @@ public record MyApplicationVo(
                 programStartDate,
                 programEndDate,
                 reviewId,
-                paymentId
+                paymentId,
+                pricePlanType
         );
     }
 }


### PR DESCRIPTION
## 요약
GET /api/v1/user/applications API에 구매한 플랜 정보(pricePlanType) 필드를 추가했습니다.

## 변경 사항
- MyApplicationVo에 `ChallengePricePlanType pricePlanType` 필드 추가
- ApplicationQueryRepositoryImpl에서 Payment 테이블과 조인하여 `challengePricePlanType` 조회