### PR TITLE
LC-2169-feat 보너스 미션 블로그 후기 참여자 직접 등록 기능 구현

### DIFF
--- a/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
@@ -61,13 +61,14 @@ public class Attendance extends BaseTimeEntity {
     private User mentor;
 
     public static Attendance createAttendance(Mission mission,
-                                              CreateAttendanceRequestDto createRequestDto,
-                                              AttendanceStatus status,
-                                              User user) {
+            CreateAttendanceRequestDto createRequestDto,
+            AttendanceStatus status,
+            User user, AttendanceResult result) {
         return Attendance.builder()
                 .link(createRequestDto.link())
                 .review(createRequestDto.review())
                 .status(status)
+                .result(result)
                 .mission(mission)
                 .user(user)
                 .build();

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/entity/Attendance.java
@@ -117,4 +117,9 @@ public class Attendance extends BaseTimeEntity {
     public void updateAttendanceFeedbackStatus(AttendanceFeedbackStatus feedbackStatus) {
         this.feedbackStatus = updateValue(this.feedbackStatus, feedbackStatus);
     }
+
+    public void updateAccountInfo(AccountType accountType, String accountNumber) {
+        this.accountType = accountType;
+        this.accountNumber = accountNumber;
+    }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/error/AttendanceErrorCode.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/error/AttendanceErrorCode.java
@@ -12,7 +12,8 @@ public enum AttendanceErrorCode implements ErrorCode {
     ATTENDANCE_NOT_AVAILABLE_DATE(HttpStatus.BAD_REQUEST, "출석 제출이 불가능한 기간입니다"),
     ATTENDANCE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "출석 수정 권한이 없습니다"),
     CONFLICT_ATTENDANCE(HttpStatus.CONFLICT, "이미 제출한 출석 내역이 존재합니다"),
-    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출석 정보를 찾을 수 없습니다.");
+    ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출석 정보를 찾을 수 없습니다"),
+    ATTENDANCE_OT_REQUIRED(HttpStatus.BAD_REQUEST, "OT를 먼저 완료해주세요");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
@@ -5,6 +5,7 @@ import org.letscareer.letscareer.domain.attendance.dto.request.CreateAttendanceR
 import org.letscareer.letscareer.domain.attendance.entity.Attendance;
 import org.letscareer.letscareer.domain.attendance.error.AttendanceErrorCode;
 import org.letscareer.letscareer.domain.attendance.repository.AttendanceRepository;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
 import org.letscareer.letscareer.domain.attendance.type.AttendanceStatus;
 import org.letscareer.letscareer.domain.attendance.vo.*;
 import org.letscareer.letscareer.domain.mission.entity.Mission;
@@ -65,8 +66,10 @@ public class AttendanceHelper {
         }
     }
 
-    public Attendance createAttendanceAndSave(Mission mission, CreateAttendanceRequestDto createRequestDto, AttendanceStatus status, User user) {
-        Attendance newAttendance = Attendance.createAttendance(mission, createRequestDto, status, user);
+    public Attendance createAttendanceAndSave(Mission mission, CreateAttendanceRequestDto createRequestDto,
+            AttendanceStatus status, User user) {
+        AttendanceResult result = (mission.getTh() == 0) ? AttendanceResult.PASS : AttendanceResult.WAITING;
+        Attendance newAttendance = Attendance.createAttendance(mission, createRequestDto, status, user, result);
         return attendanceRepository.save(newAttendance);
     }
 
@@ -76,5 +79,10 @@ public class AttendanceHelper {
 
     public List<MissionReviewAdminVo> findAllMissionReviewAdminVos() {
         return attendanceRepository.findAllMissionReviewAdminVos();
+    }
+
+    public boolean isOTCompleted(Long challengeId, Long userId) {
+        return attendanceRepository.existsByMissionChallengeIdAndMissionThAndUserIdAndResult(challengeId, 0, userId,
+                AttendanceResult.PASS);
     }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/helper/AttendanceHelper.java
@@ -81,6 +81,10 @@ public class AttendanceHelper {
         return attendanceRepository.findAllMissionReviewAdminVos();
     }
 
+    public Attendance saveAttendance(Attendance attendance) {
+        return attendanceRepository.save(attendance);
+    }
+
     public boolean isOTCompleted(Long challengeId, Long userId) {
         return attendanceRepository.existsByMissionChallengeIdAndMissionThAndUserIdAndResult(challengeId, 0, userId,
                 AttendanceResult.PASS);

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
@@ -8,7 +8,5 @@ import java.util.Optional;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long>, AttendanceQueryRepository {
     Optional<Attendance> findAttendanceByMissionIdAndUserId(Long missionId, Long userId);
-
-    boolean existsByMissionChallengeIdAndMissionThAndUserIdAndResult(
-            Long challengeId, Integer th, Long userId, AttendanceResult result);
+    boolean existsByMissionChallengeIdAndMissionThAndUserIdAndResult(Long challengeId, Integer th, Long userId, AttendanceResult result);
 }

--- a/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/org/letscareer/letscareer/domain/attendance/repository/AttendanceRepository.java
@@ -1,10 +1,14 @@
 package org.letscareer.letscareer.domain.attendance.repository;
 
 import org.letscareer.letscareer.domain.attendance.entity.Attendance;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long>, AttendanceQueryRepository {
     Optional<Attendance> findAttendanceByMissionIdAndUserId(Long missionId, Long userId);
+
+    boolean existsByMissionChallengeIdAndMissionThAndUserIdAndResult(
+            Long challengeId, Integer th, Long userId, AttendanceResult result);
 }

--- a/src/main/java/org/letscareer/letscareer/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/challenge/service/ChallengeServiceImpl.java
@@ -88,6 +88,7 @@ import org.letscareer.letscareer.domain.user.type.UserRole;
 import org.letscareer.letscareer.global.common.entity.PageInfo;
 import org.letscareer.letscareer.global.common.utils.zoom.ZoomUtils;
 import org.letscareer.letscareer.global.error.exception.EntityNotFoundException;
+import org.letscareer.letscareer.global.error.exception.InvalidValueException;
 import org.letscareer.letscareer.global.error.exception.UnauthorizedException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -101,6 +102,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.letscareer.letscareer.domain.application.error.ApplicationErrorCode.APPLICATION_NOT_FOUND;
+import static org.letscareer.letscareer.domain.attendance.error.AttendanceErrorCode.ATTENDANCE_OT_REQUIRED;
 import static org.letscareer.letscareer.domain.user.error.UserErrorCode.IS_NOT_MENTOR;
 
 @RequiredArgsConstructor
@@ -329,6 +331,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     public GetChallengeMyMissionDetailResponseDto getMyMissionDetail(Long challengeId, Long missionId, User user) {
         challengeApplicationHelper.validateChallengeDashboardAccessibleUser(challengeId, user);
         MyDailyMissionVo missionInfo = missionHelper.findMyDailyMissionVoByMissionId(missionId);
+        
+        if (missionInfo != null && missionInfo.th() >= 1 && !attendanceHelper.isOTCompleted(challengeId, user.getId())) {
+            throw new InvalidValueException(ATTENDANCE_OT_REQUIRED);
+        }
+        
         AttendanceDashboardVo attendanceInfo = missionInfo != null ? attendanceHelper.findAttendanceDashboardVoOrNull(missionInfo.id(), user.getId()) : null;
         return missionMapper.toGetChallengeMyMissionDetailResponseDto(missionInfo, attendanceInfo);
     }

--- a/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/repository/MissionQueryRepositoryImpl.java
@@ -132,7 +132,8 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                                 missionTemplate.missionTag,
                                 missionTemplate.description,
                                 missionTemplate.guide,
-                                missionTemplate.templateLink))
+                                missionTemplate.templateLink,
+                                missionTemplate.vodLink))
                         .from(mission)
                         .leftJoin(mission.missionTemplate, missionTemplate)
                         .where(
@@ -292,7 +293,8 @@ public class MissionQueryRepositoryImpl implements MissionQueryRepository {
                                 missionTemplate.missionTag,
                                 missionTemplate.description,
                                 missionTemplate.guide,
-                                missionTemplate.templateLink))
+                                missionTemplate.templateLink,
+                                missionTemplate.vodLink))
                         .from(mission)
                         .leftJoin(mission.missionTemplate, missionTemplate)
                         .where(

--- a/src/main/java/org/letscareer/letscareer/domain/mission/vo/MyDailyMissionVo.java
+++ b/src/main/java/org/letscareer/letscareer/domain/mission/vo/MyDailyMissionVo.java
@@ -22,9 +22,9 @@ public record MyDailyMissionVo(
         String missionTag,
         String description,
         String guide,
-        String templateLink
-) {
-    public MyDailyMissionVo(Mission mission, String missionTag, String description, String guide, String templateLink) {
+        String templateLink,
+        String vodLink) {
+    public MyDailyMissionVo(Mission mission, String missionTag, String description, String guide, String templateLink, String vodLink) {
         this(
                 mission.getId(),
                 mission.getTh(),
@@ -41,8 +41,8 @@ public record MyDailyMissionVo(
                 missionTag,
                 description,
                 guide,
-                templateLink
-        );
+                templateLink,
+                vodLink);
 
     }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/review/controller/ReviewV2Controller.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/controller/ReviewV2Controller.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.letscareer.letscareer.domain.challenge.type.ChallengeType;
 import org.letscareer.letscareer.domain.program.type.ProgramType;
 import org.letscareer.letscareer.domain.review.dto.request.*;
+import org.letscareer.letscareer.domain.review.dto.response.CreateUserBlogReviewResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetBlogReviewResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetMyReviewResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetReviewCountResponseDto;
@@ -101,5 +102,17 @@ public class ReviewV2Controller {
                                                             @CurrentUser final User user) {
         reviewServiceFactory.getReviewService(requestDto.type()).createReview(user, applicationId, requestDto);
         return SuccessResponse.created(null);
+    }
+
+    @Operation(
+            summary = "보너스 미션 블로그 후기 제출",
+            description = "참여자가 보너스 미션의 블로그 후기 URL을 제출하면 자동으로 BlogReview와 Attendance가 생성됩니다.",
+            responses = {@ApiResponse(responseCode = "201", content = @Content(schema = @Schema(implementation = CreateUserBlogReviewResponseDto.class)))}
+    )
+    @PostMapping("/blog/bonus")
+    private ResponseEntity<SuccessResponse<?>> createUserBlogReview(@RequestBody @Valid final CreateUserBlogReviewRequestDto requestDto,
+                                                                   @CurrentUser final User user) {
+        CreateUserBlogReviewResponseDto responseDto = blogReviewService.createUserBlogReview(requestDto, user);
+        return SuccessResponse.created(responseDto);
     }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/review/dto/request/CreateUserBlogReviewRequestDto.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/dto/request/CreateUserBlogReviewRequestDto.java
@@ -1,0 +1,12 @@
+package org.letscareer.letscareer.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateUserBlogReviewRequestDto(
+        @NotNull Long missionId,
+        @NotBlank String url,
+        String bankName,
+        String accountNumber
+) {
+}

--- a/src/main/java/org/letscareer/letscareer/domain/review/dto/request/CreateUserBlogReviewRequestDto.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/dto/request/CreateUserBlogReviewRequestDto.java
@@ -2,11 +2,12 @@ package org.letscareer.letscareer.domain.review.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.letscareer.letscareer.domain.user.type.AccountType;
 
 public record CreateUserBlogReviewRequestDto(
         @NotNull Long missionId,
         @NotBlank String url,
-        String bankName,
+        AccountType accountType,
         String accountNumber
 ) {
 }

--- a/src/main/java/org/letscareer/letscareer/domain/review/dto/response/CreateUserBlogReviewResponseDto.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/dto/response/CreateUserBlogReviewResponseDto.java
@@ -1,0 +1,15 @@
+package org.letscareer.letscareer.domain.review.dto.response;
+
+public record CreateUserBlogReviewResponseDto(
+        Long blogReviewId,
+        Long attendanceId,
+        String message
+) {
+    public static CreateUserBlogReviewResponseDto of(Long blogReviewId, Long attendanceId) {
+        return new CreateUserBlogReviewResponseDto(
+                blogReviewId,
+                attendanceId,
+                "블로그 후기가 성공적으로 제출되었습니다. 관리자 승인 후 공개됩니다."
+        );
+    }
+}

--- a/src/main/java/org/letscareer/letscareer/domain/review/entity/BlogReview.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/entity/BlogReview.java
@@ -62,7 +62,21 @@ public class BlogReview {
                 .build();
     }
 
-    public void setThumbnail(String thumbnail) {
+    public static BlogReview createBonusBlogReview(CreateBlogReviewRequestDto requestDto, BlogReviewOpenGraphVo openGraphVo, Attendance attendance) {
+        return BlogReview.builder()
+                .programType(requestDto.programType())
+                .programTitle(requestDto.programTitle())
+                .name(requestDto.name())
+                .title(openGraphVo.title())
+                .description(openGraphVo.description())
+                .url(openGraphVo.url())
+                .postDate(requestDto.postDate())
+                .attendance(attendance)
+                .isVisible(true)
+                .build();
+    }
+
+    public void updateThumbnail(String thumbnail) {
         this.thumbnail = thumbnail;
     }
 
@@ -79,5 +93,9 @@ public class BlogReview {
         this.description = updateValue(this.description, openGraphVo.description());
         this.url = updateValue(this.url, openGraphVo.url());
         this.thumbnail = updateValue(this.thumbnail, thumbnail);
+    }
+
+    public void approveForBonus() {
+        this.isVisible = true;
     }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/review/helper/BlogReviewHelper.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/helper/BlogReviewHelper.java
@@ -1,6 +1,7 @@
 package org.letscareer.letscareer.domain.review.helper;
 
 import lombok.RequiredArgsConstructor;
+import org.letscareer.letscareer.domain.attendance.entity.Attendance;
 import org.letscareer.letscareer.domain.program.type.ProgramType;
 import org.letscareer.letscareer.domain.review.dto.request.CreateBlogReviewRequestDto;
 import org.letscareer.letscareer.domain.review.entity.BlogReview;
@@ -24,6 +25,11 @@ public class BlogReviewHelper {
 
     public BlogReview createBlogReviewAndSave(CreateBlogReviewRequestDto requestDto, BlogReviewOpenGraphVo openGraphVo) {
         BlogReview blogReview = BlogReview.createBlogReview(requestDto, openGraphVo);
+        return blogReviewRepository.save(blogReview);
+    }
+
+    public BlogReview createBonusBlogReviewAndSave(CreateBlogReviewRequestDto requestDto, BlogReviewOpenGraphVo openGraphVo, Attendance attendance) {
+        BlogReview blogReview = BlogReview.createBonusBlogReview(requestDto, openGraphVo, attendance);
         return blogReviewRepository.save(blogReview);
     }
 

--- a/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewService.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewService.java
@@ -2,9 +2,12 @@ package org.letscareer.letscareer.domain.review.service;
 
 import org.letscareer.letscareer.domain.program.type.ProgramType;
 import org.letscareer.letscareer.domain.review.dto.request.CreateBlogReviewRequestDto;
+import org.letscareer.letscareer.domain.review.dto.request.CreateUserBlogReviewRequestDto;
 import org.letscareer.letscareer.domain.review.dto.request.UpdateBlogReviewRequestDto;
+import org.letscareer.letscareer.domain.review.dto.response.CreateUserBlogReviewResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetBlogReviewForAdminResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetBlogReviewResponseDto;
+import org.letscareer.letscareer.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -15,4 +18,5 @@ public interface BlogReviewService {
     void createBlogReview(CreateBlogReviewRequestDto requestDto);
     void updateBlogReview(Long blogReviewId, UpdateBlogReviewRequestDto requestDto);
     void deleteBlogReview(Long blogReviewId);
+    CreateUserBlogReviewResponseDto createUserBlogReview(CreateUserBlogReviewRequestDto requestDto, User user);
 }

--- a/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewServiceImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewServiceImpl.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.letscareer.letscareer.domain.file.type.FileType;
 import org.letscareer.letscareer.domain.program.type.ProgramType;
 import org.letscareer.letscareer.domain.review.dto.request.CreateBlogReviewRequestDto;
+import org.letscareer.letscareer.domain.review.dto.request.CreateUserBlogReviewRequestDto;
 import org.letscareer.letscareer.domain.review.dto.request.UpdateBlogReviewRequestDto;
+import org.letscareer.letscareer.domain.review.dto.response.CreateUserBlogReviewResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetBlogReviewForAdminResponseDto;
 import org.letscareer.letscareer.domain.review.dto.response.GetBlogReviewResponseDto;
 import org.letscareer.letscareer.domain.review.entity.BlogReview;
@@ -16,11 +18,21 @@ import org.letscareer.letscareer.domain.review.vo.BlogReviewVo;
 import org.letscareer.letscareer.global.common.entity.PageInfo;
 import org.letscareer.letscareer.global.common.utils.aws.S3Utils;
 import org.letscareer.letscareer.global.common.utils.opengraph.OpenGraphUtils;
+import org.letscareer.letscareer.domain.attendance.entity.Attendance;
+import org.letscareer.letscareer.domain.attendance.helper.AttendanceHelper;
+import org.letscareer.letscareer.domain.attendance.dto.request.CreateAttendanceRequestDto;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceStatus;
+import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
+import org.letscareer.letscareer.domain.mission.entity.Mission;
+import org.letscareer.letscareer.domain.mission.helper.MissionHelper;
+import org.letscareer.letscareer.domain.user.entity.User;
+import org.letscareer.letscareer.domain.user.type.AccountType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,6 +44,8 @@ public class BlogReviewServiceImpl implements BlogReviewService {
     private final OpenGraphUtils openGraphUtils;
     private final S3Utils s3Utils;
     private final ReviewMapper reviewMapper;
+    private final AttendanceHelper attendanceHelper;
+    private final MissionHelper missionHelper;
 
     @Override
     public GetBlogReviewResponseDto getBlogReviews(List<ProgramType> typeList, Pageable pageable) {
@@ -52,7 +66,7 @@ public class BlogReviewServiceImpl implements BlogReviewService {
         BlogReview blogReview = blogReviewHelper.createBlogReviewAndSave(requestDto, openGraphVo);
         if(!Objects.isNull(openGraphVo.image())) {
             String thumbnail = s3Utils.saveImgFromUrl(openGraphVo.image(), FileType.BLOG_REVIEW.getDesc(), blogReview.getId() + openGraphVo.title()).getUrl();
-            blogReview.setThumbnail(thumbnail);
+            blogReview.updateThumbnail(thumbnail);
         }
     }
 
@@ -72,6 +86,48 @@ public class BlogReviewServiceImpl implements BlogReviewService {
         BlogReview blogReview = blogReviewHelper.findBlogReviewByBlogReviewIdOrThrow(blogReviewId);
         s3Utils.deleteFile(FileType.BLOG_REVIEW.getDesc() + blogReview.getId() + blogReview.getTitle());
         blogReviewHelper.deleteBlogReview(blogReview);
+    }
+
+    @Override
+    public CreateUserBlogReviewResponseDto createUserBlogReview(CreateUserBlogReviewRequestDto requestDto, User user) {
+        Mission mission = missionHelper.findMissionByIdOrThrow(requestDto.missionId());
+        
+        CreateAttendanceRequestDto attendanceRequestDto = new CreateAttendanceRequestDto(
+                requestDto.url(), 
+                "보너스 미션 블로그 후기 제출"
+        );
+        
+        Attendance attendance = Attendance.createAttendance(
+                mission, 
+                attendanceRequestDto, 
+                AttendanceStatus.PRESENT, 
+                user, 
+                AttendanceResult.PASS
+        );
+        AccountType accountType = requestDto.bankName() != null ? 
+                AccountType.fromBankName(requestDto.bankName()) : null;
+        attendance.updateAccountInfo(accountType, requestDto.accountNumber());
+        
+        attendance = attendanceHelper.saveAttendance(attendance);
+        BlogReviewOpenGraphVo openGraphVo = openGraphUtils.getBlogReviewOpenGraphVo(requestDto.url());
+        
+        CreateBlogReviewRequestDto blogReviewRequestDto = new CreateBlogReviewRequestDto(
+                ProgramType.CHALLENGE,
+                mission.getChallenge().getTitle(),
+                user.getName(),
+                requestDto.url(),
+                LocalDateTime.now()
+        );
+        
+        BlogReview blogReview = blogReviewHelper.createBonusBlogReviewAndSave(blogReviewRequestDto, openGraphVo, attendance);
+        
+        if (!Objects.isNull(openGraphVo.image())) {
+            String thumbnail = s3Utils.saveImgFromUrl(openGraphVo.image(), FileType.BLOG_REVIEW.getDesc(), 
+                    blogReview.getId() + openGraphVo.title()).getUrl();
+            blogReview.updateThumbnail(thumbnail);
+        }
+        
+        return CreateUserBlogReviewResponseDto.of(blogReview.getId(), attendance.getId());
     }
 
     private boolean checkBlogReviewUrlUpdateCondition(BlogReview blogReview, UpdateBlogReviewRequestDto requestDto) {

--- a/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewServiceImpl.java
+++ b/src/main/java/org/letscareer/letscareer/domain/review/service/BlogReviewServiceImpl.java
@@ -26,7 +26,6 @@ import org.letscareer.letscareer.domain.attendance.type.AttendanceResult;
 import org.letscareer.letscareer.domain.mission.entity.Mission;
 import org.letscareer.letscareer.domain.mission.helper.MissionHelper;
 import org.letscareer.letscareer.domain.user.entity.User;
-import org.letscareer.letscareer.domain.user.type.AccountType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -104,9 +103,7 @@ public class BlogReviewServiceImpl implements BlogReviewService {
                 user, 
                 AttendanceResult.PASS
         );
-        AccountType accountType = requestDto.bankName() != null ? 
-                AccountType.fromBankName(requestDto.bankName()) : null;
-        attendance.updateAccountInfo(accountType, requestDto.accountNumber());
+        attendance.updateAccountInfo(requestDto.accountType(), requestDto.accountNumber());
         
         attendance = attendanceHelper.saveAttendance(attendance);
         BlogReviewOpenGraphVo openGraphVo = openGraphUtils.getBlogReviewOpenGraphVo(requestDto.url());

--- a/src/main/java/org/letscareer/letscareer/domain/user/type/AccountType.java
+++ b/src/main/java/org/letscareer/letscareer/domain/user/type/AccountType.java
@@ -21,4 +21,15 @@ public enum AccountType implements EnumField {
 
     private final Integer code;
     private final String desc;
+    
+    public static AccountType fromBankName(String bankName) {
+        if (bankName == null) return null;
+        
+        for (AccountType type : AccountType.values()) {
+            if (type.desc.equals(bankName) || bankName.contains(type.desc)) {
+                return type;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/letscareer/letscareer/domain/user/type/AccountType.java
+++ b/src/main/java/org/letscareer/letscareer/domain/user/type/AccountType.java
@@ -21,15 +21,4 @@ public enum AccountType implements EnumField {
 
     private final Integer code;
     private final String desc;
-    
-    public static AccountType fromBankName(String bankName) {
-        if (bankName == null) return null;
-        
-        for (AccountType type : AccountType.values()) {
-            if (type.desc.equals(bankName) || bankName.contains(type.desc)) {
-                return type;
-            }
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
## 요약
보너스 미션에서 참여자가 블로그 후기 URL을 직접 입력할 수 있는 기능을 구현했습니다.
기존 어드민에서만 등록 가능했던 블로그 후기를 참여자가 직접 제출할 수 있도록 구현했습니다.

## 변경 사항
### User 블로그 후기 등록 API
- **엔드포인트**: `POST /api/v2/review/blog/bonus`
